### PR TITLE
fix: tighten GitLab URL detection

### DIFF
--- a/src/mcp_gitlab/git_detector.py
+++ b/src/mcp_gitlab/git_detector.py
@@ -264,5 +264,8 @@ class GitDetector:
             url_host = parsed["host"].lower().replace("www.", "")
             check_host = gitlab_host.lower().replace("www.", "").replace("https://", "").replace("http://", "").split("/")[0]
             return url_host == check_host
-        
-        return True
+        # Default behavior: ensure the URL points to a GitLab host
+        # Some non-GitLab URLs (like GitHub) can still be parsed by
+        # ``parse_gitlab_url``; we only want to return True when the
+        # host clearly refers to a GitLab instance.
+        return "gitlab" in parsed["host"].lower()

--- a/tests/test_git_detector.py
+++ b/tests/test_git_detector.py
@@ -235,6 +235,8 @@ class TestGitDetector:
         # Invalid URLs
         assert GitDetector.is_gitlab_url("not-a-url") is False
         assert GitDetector.is_gitlab_url("https://gitlab.com/project") is False
+        # Non-GitLab host should also return False
+        assert GitDetector.is_gitlab_url("https://github.com/user/repo.git") is False
     
     @pytest.mark.unit
     def test_is_gitlab_url_with_host_check(self):


### PR DESCRIPTION
## Summary
- ensure `GitDetector.is_gitlab_url` rejects non-GitLab hosts
- add regression test for non-GitLab URLs

## Testing
- `./run_tests.sh` *(fails: Could not find a version that satisfies the requirement hatchling; unrecognized arguments: --cov)*

------
https://chatgpt.com/codex/tasks/task_e_6895786f895c8332bdfd8d8d38c9e627