### PR TITLE
Add tests for merge request handlers and support running without optional deps

### DIFF
--- a/src/mcp_gitlab/__init__.py
+++ b/src/mcp_gitlab/__init__.py
@@ -1,5 +1,23 @@
-from .server import server, main
+"""Public package interface for mcp_gitlab.
+
+The server component depends on the optional ``mcp`` package.  Importing it in
+environments where the dependency is unavailable would raise an ImportError and
+prevent access to the remaining utility modules.  To make the package more
+robust for unit tests we try to import the server lazily and fall back to
+lightweight placeholders when the import fails.
+"""
+
 from .gitlab_client import GitLabClient, GitLabConfig
 
+__all__ = ["GitLabClient", "GitLabConfig"]
+
+try:  # pragma: no cover - exercised implicitly during import
+    from .server import server, main  # type: ignore
+    __all__.extend(["server", "main"])
+except Exception:  # pylint: disable=broad-except
+    server = None  # type: ignore
+
+    def main(*args, **kwargs):  # pragma: no cover - placeholder function
+        raise ImportError("MCP server dependencies are not installed")
+
 __version__ = "0.1.0"
-__all__ = ["server", "main", "GitLabClient", "GitLabConfig"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,223 @@
-"""Shared test fixtures and configuration"""
+"""Shared test fixtures and configuration
+
+This file also provides lightweight stub implementations of optional
+dependencies so that the test suite can run in environments where the real
+packages (``python-gitlab`` and ``mcp``) are not installed. The production
+code only touches a very small portion of these libraries in unit tests, so
+simple placeholder objects are sufficient. If the real packages are
+available they will be used instead and these stubs have no effect.
+"""
 import pytest
 import os
 import tempfile
 from unittest.mock import Mock, patch
+import types
+import sys
+
+# ---------------------------------------------------------------------------
+# Optional dependency stubs
+# ---------------------------------------------------------------------------
+
+# Provide a minimal stub for the ``gitlab`` package if it's missing.  The
+# handlers and client only require that ``gitlab.Gitlab`` exists so tests can
+# patch it, as well as modules for ``gitlab.exceptions`` and
+# ``gitlab.v4.objects`` with placeholder classes.
+if "gitlab" not in sys.modules:
+    gitlab_module = types.ModuleType("gitlab")
+    exceptions_module = types.ModuleType("gitlab.exceptions")
+    v4_module = types.ModuleType("gitlab.v4")
+    objects_module = types.ModuleType("gitlab.v4.objects")
+
+    # Basic placeholder classes used in type hints or patched in tests
+    class Gitlab:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class Project:  # pragma: no cover - simple stub
+        pass
+
+    class Issue:  # pragma: no cover - simple stub
+        pass
+
+    class MergeRequest:  # pragma: no cover - simple stub
+        pass
+
+    gitlab_module.Gitlab = Gitlab
+    gitlab_module.exceptions = exceptions_module
+    gitlab_module.v4 = v4_module
+    v4_module.objects = objects_module
+    objects_module.Project = Project
+    objects_module.Issue = Issue
+    objects_module.MergeRequest = MergeRequest
+
+    # Common exception classes referenced in the code/tests
+    class GitlabError(Exception):
+        pass
+
+    class GitlabGetError(GitlabError):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+            self.response_code = kwargs.get("response_code")
+
+    class GitlabAuthenticationError(GitlabError):
+        pass
+
+    class GitlabHttpError(GitlabError):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+            self.response_code = kwargs.get("response_code")
+
+    class GitlabListError(GitlabError):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+            self.response_code = kwargs.get("response_code")
+
+    class GitlabCreateError(GitlabError):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+            self.response_code = kwargs.get("response_code")
+
+    class GitlabUpdateError(GitlabError):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+            self.response_code = kwargs.get("response_code")
+
+    class GitlabDeleteError(GitlabError):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+            self.response_code = kwargs.get("response_code")
+
+    exceptions_module.GitlabError = GitlabError
+    exceptions_module.GitlabGetError = GitlabGetError
+    exceptions_module.GitlabAuthenticationError = GitlabAuthenticationError
+    exceptions_module.GitlabHttpError = GitlabHttpError
+    exceptions_module.GitlabListError = GitlabListError
+    exceptions_module.GitlabCreateError = GitlabCreateError
+    exceptions_module.GitlabUpdateError = GitlabUpdateError
+    exceptions_module.GitlabDeleteError = GitlabDeleteError
+
+    sys.modules["gitlab"] = gitlab_module
+    sys.modules["gitlab.exceptions"] = exceptions_module
+    sys.modules["gitlab.v4"] = v4_module
+    sys.modules["gitlab.v4.objects"] = objects_module
+
+# Provide a minimal stub for the ``mcp`` package when it's not installed.
+# Only a handful of classes/functions are required for the tests.
+if "mcp" not in sys.modules:
+    mcp_module = types.ModuleType("mcp")
+    server_module = types.ModuleType("mcp.server")
+    models_module = types.ModuleType("mcp.server.models")
+    stdio_module = types.ModuleType("mcp.server.stdio")
+    types_module = types.ModuleType("mcp.types")
+
+    class Server:  # pragma: no cover - simple stub
+        """Very small stand-in for mcp.server.Server used in tests.
+
+        It only implements the decorator methods utilized by the server
+        module. The decorators simply return the wrapped function unchanged.
+        """
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def list_tools(self):  # pragma: no cover - simple stub
+            def decorator(func):
+                return func
+            return decorator
+
+        def call_tool(self):  # pragma: no cover - simple stub
+            def decorator(func):
+                return func
+            return decorator
+
+        def get_capabilities(self, *args, **kwargs):  # pragma: no cover - stub
+            return {}
+
+        async def run(self, *args, **kwargs):  # pragma: no cover - stub
+            return None
+
+    class NotificationOptions:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class InitializationOptions:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def stdio_server(*args, **kwargs):  # pragma: no cover - simple stub
+        pass
+
+    # Simple classes used for responses in the server module
+    class Tool:  # pragma: no cover - simple stub
+        def __init__(self, name: str, description: str = "", inputSchema: dict | None = None):
+            self.name = name
+            self.description = description
+            self.inputSchema = inputSchema
+
+    class TextContent:  # pragma: no cover - simple stub
+        def __init__(self, type: str = "text", text: str = ""):
+            self.type = type
+            self.text = text
+
+    class ImageContent:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class EmbeddedResource:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    server_module.Server = Server
+    server_module.NotificationOptions = NotificationOptions
+    stdio_module.stdio_server = stdio_server
+    models_module.InitializationOptions = InitializationOptions
+
+    types_module.Tool = Tool
+    types_module.TextContent = TextContent
+    types_module.ImageContent = ImageContent
+    types_module.EmbeddedResource = EmbeddedResource
+
+    mcp_module.server = server_module
+    mcp_module.types = types_module
+
+    sys.modules["mcp"] = mcp_module
+    sys.modules["mcp.server"] = server_module
+    sys.modules["mcp.server.models"] = models_module
+    sys.modules["mcp.server.stdio"] = stdio_module
+    sys.modules["mcp.types"] = types_module
+
+# Provide extremely small pydantic stand-ins when the library isn't
+# available.  They only implement the pieces required for test execution.
+if "pydantic" not in sys.modules:
+    pydantic_module = types.ModuleType("pydantic")
+
+    class BaseModel:  # pragma: no cover - simple stub
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    def Field(default=None, **kwargs):  # pragma: no cover - simple stub
+        return default
+
+    class AnyUrl(str):  # pragma: no cover - simple stub
+        pass
+
+    pydantic_module.BaseModel = BaseModel
+    pydantic_module.Field = Field
+    pydantic_module.AnyUrl = AnyUrl
+
+    sys.modules["pydantic"] = pydantic_module
+
+# Minimal stub for python-dotenv when not installed.
+if "dotenv" not in sys.modules:
+    dotenv_module = types.ModuleType("dotenv")
+
+    def load_dotenv(*args, **kwargs):  # pragma: no cover - simple stub
+        return None
+
+    dotenv_module.load_dotenv = load_dotenv
+    sys.modules["dotenv"] = dotenv_module
+
 
 # Test constants
 TEST_USER_NAME = "Test User"
@@ -247,3 +462,27 @@ def mock_env_vars(monkeypatch):
     monkeypatch.setenv("GITLAB_PRIVATE_TOKEN", "test-token-env")
     monkeypatch.setenv("GITLAB_DEFAULT_PAGE_SIZE", "25")
     monkeypatch.setenv("GITLAB_LOG_LEVEL", "DEBUG")
+
+
+# ---------------------------------------------------------------------------
+# Asyncio test support
+# ---------------------------------------------------------------------------
+import asyncio
+
+
+def pytest_configure(config):  # pragma: no cover - test harness setup
+    config.addinivalue_line("markers", "asyncio: mark test to run on event loop")
+
+
+import inspect
+
+
+@pytest.hookimpl()
+def pytest_pyfunc_call(pyfuncitem):  # pragma: no cover - test harness setup
+    if pyfuncitem.get_closest_marker("asyncio"):
+        func = pyfuncitem.obj
+        params = inspect.signature(func).parameters
+        kwargs = {name: pyfuncitem.funcargs[name] for name in params}
+        asyncio.run(func(**kwargs))
+        return True
+    return None


### PR DESCRIPTION
## Summary
- add comprehensive unit tests for merge request tool handlers
- stub external dependencies and lazy-load server to allow test execution without gitlab or mcp packages

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896e37924188332aacf7e8f2420a9a0